### PR TITLE
Add HelpCommand to give help to users

### DIFF
--- a/src/main/java/hermione/commands/ExitCommand.java
+++ b/src/main/java/hermione/commands/ExitCommand.java
@@ -1,5 +1,6 @@
 package hermione.commands;
 
+import hermione.storage.TaskStorage;
 import hermione.ui.console.ConsoleUi;
 import javafx.application.Platform;
 
@@ -7,8 +8,8 @@ import javafx.application.Platform;
  * Represents a command to exit the Hermione application.
  */
 public class ExitCommand extends Command {
-    public ExitCommand(String argument) {
-        super(null, argument);
+    public ExitCommand(TaskStorage storage, String argument) {
+        super(storage, argument);
     }
 
     /**

--- a/src/main/java/hermione/commands/HelpCommand.java
+++ b/src/main/java/hermione/commands/HelpCommand.java
@@ -1,0 +1,43 @@
+package hermione.commands;
+
+import hermione.storage.TaskStorage;
+
+/**
+ * Represents a command to display help information in the Hermione application.
+ */
+public class HelpCommand extends Command {
+
+    /**
+     * Constructor for the HelpCommand class.
+     *
+     * @param storage  The TaskStorage instance used to manage tasks.
+     * @param argument The argument string that contains the command details.
+     */
+    public HelpCommand(TaskStorage storage, String argument) {
+        super(storage, argument);
+    }
+
+    /**
+     * Executes the command to display help information.
+     * This method returns a string containing a list of available commands
+     * and their descriptions.
+     *
+     * @return A string containing help information for the user.
+     */
+    @Override
+    public String execute() {
+        return """
+                Available commands:
+                1. help - Show this help message
+                2. exit - Exit the application
+                3. list - List all items
+                4. todo {description} - Add a new ToDo task
+                5. deadline {description} /by {date} - Add a new Deadline task
+                6. event {description} /from {start date} /to {end date} - Add a new Event task
+                7. mark {task number} - Mark a task as completed
+                8. unmark {task number} - Unmark a task as not completed
+                9. delete {task number} - Delete a task
+                10. find {keyword} - Find tasks containing the keyword
+                """;
+    }
+}

--- a/src/main/java/hermione/ui/common/CommandParser.java
+++ b/src/main/java/hermione/ui/common/CommandParser.java
@@ -6,6 +6,7 @@ import hermione.commands.DeleteCommand;
 import hermione.commands.EventCommand;
 import hermione.commands.ExitCommand;
 import hermione.commands.FindCommand;
+import hermione.commands.HelpCommand;
 import hermione.commands.ListCommand;
 import hermione.commands.MarkCommand;
 import hermione.commands.ToDoCommand;
@@ -40,7 +41,8 @@ public class CommandParser {
             case "unmark" -> new UnmarkCommand(storage, argument);
             case "list" -> new ListCommand(storage, argument);
             case "find" -> new FindCommand(storage, argument);
-            case "bye" -> new ExitCommand(argument);
+            case "bye" -> new ExitCommand(storage, argument);
+            case "help" -> new HelpCommand(storage, argument);
             default -> throw new InvalidCommandException(command);
         };
     }


### PR DESCRIPTION
Users do not have any documentation to see what commands are available to use in the chatbot.

Let's,
* add help command to show all available commands to users